### PR TITLE
#5_都道府県チェックボックス（モック）の作成

### DIFF
--- a/src/features/prefecture-population/components/prefecture-checkboxes/PrefectureCheckboxes.module.css
+++ b/src/features/prefecture-population/components/prefecture-checkboxes/PrefectureCheckboxes.module.css
@@ -1,0 +1,19 @@
+.checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  grid-gap: 1px;
+}
+
+.checkbox {
+  padding: 10px;
+  border-radius: 5px;
+}
+
+.checkbox:hover {
+  background-color: aliceblue;
+  cursor: pointer;
+}
+
+.checkboxLabel {
+  margin-left: 5px;
+}

--- a/src/features/prefecture-population/components/prefecture-checkboxes/PrefectureCheckboxes.stories.tsx
+++ b/src/features/prefecture-population/components/prefecture-checkboxes/PrefectureCheckboxes.stories.tsx
@@ -1,0 +1,67 @@
+import { ComponentMeta } from "@storybook/react";
+import { useState } from "react";
+import { PrefectureCheckbox } from "../../types";
+import PrefectureCheckboxes from "./PrefectureCheckboxes";
+
+export default {
+  component: PrefectureCheckboxes,
+} as ComponentMeta<typeof PrefectureCheckboxes>;
+
+export const Default = {
+  render: () => {
+    const [prefectureCheckboxes, setPrefectureCheckboxes] = useState<
+      PrefectureCheckbox[]
+    >([
+      {
+        prefCode: 1,
+        prefName: "東京都",
+        isChecked: false,
+      },
+      {
+        prefCode: 2,
+        prefName: "大阪府",
+        isChecked: false,
+      },
+      {
+        prefCode: 3,
+        prefName: "東京都",
+        isChecked: false,
+      },
+      {
+        prefCode: 4,
+        prefName: "大阪府",
+        isChecked: false,
+      },
+      {
+        prefCode: 5,
+        prefName: "大阪府",
+        isChecked: false,
+      },
+      {
+        prefCode: 6,
+        prefName: "大阪府",
+        isChecked: false,
+      },
+    ]);
+
+    const toggle = (prefCode: number) => {
+      setPrefectureCheckboxes((prev) =>
+        prev.map((prefectureCheckbox) => {
+          if (prefectureCheckbox.prefCode !== prefCode) {
+            return prefectureCheckbox;
+          }
+          return {
+            ...prefectureCheckbox,
+            isSelected: !prefectureCheckbox.isChecked,
+          };
+        })
+      );
+    };
+    return (
+      <PrefectureCheckboxes
+        prefectureCheckboxes={prefectureCheckboxes}
+        toggle={toggle}
+      />
+    );
+  },
+};

--- a/src/features/prefecture-population/components/prefecture-checkboxes/PrefectureCheckboxes.tsx
+++ b/src/features/prefecture-population/components/prefecture-checkboxes/PrefectureCheckboxes.tsx
@@ -1,0 +1,31 @@
+import { PrefectureCheckbox } from "../../types";
+import PrefectureCheckBoxess from "./PrefectureCheckBoxes.module.css";
+
+type Props = {
+  prefectureCheckboxes: PrefectureCheckbox[];
+  toggle: (prefCode: number) => void;
+};
+
+const PrefectureCheckboxes = ({ prefectureCheckboxes, toggle }: Props) => {
+  return (
+    <div className={PrefectureCheckBoxess.checkboxes}>
+      {prefectureCheckboxes.map((prefectureCheckbox) => (
+        <label
+          key={prefectureCheckbox.prefCode}
+          className={PrefectureCheckBoxess.checkbox}
+        >
+          <input
+            type="checkbox"
+            onChange={() => toggle(prefectureCheckbox.prefCode)}
+            checked={prefectureCheckbox.isChecked}
+          />
+          <span className={PrefectureCheckBoxess.checkboxLabel}>
+            {prefectureCheckbox.prefName}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+};
+
+export default PrefectureCheckboxes;

--- a/src/features/prefecture-population/types/index.ts
+++ b/src/features/prefecture-population/types/index.ts
@@ -1,0 +1,8 @@
+export type Prefecture = {
+  prefCode: number;
+  prefName: string;
+};
+
+export type PrefectureCheckbox = Prefecture & {
+  isChecked: boolean;
+};


### PR DESCRIPTION
## issue
- #5 

## why
- 都道府県を選択するために必要だから

## what
- 各種型(Prefecture/PrefectureCheckbox)を定義
- PrefectureCheckboxesコンポーネントの実装
- storiesの作成

## UIスクリーンショット
![Screenshot 2023-02-09 at 04-36-06 features _ prefecture-population _ components _ prefecture-checkboxes _ PrefectureCheckboxes - Default ⋅ Storybook](https://user-images.githubusercontent.com/106266114/217634118-4823c2a6-f1dd-4b6e-aebb-2678205d4abb.png)
