### PR TITLE
#7_総人口推移グラフ（モック）の作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "yumemi-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "highcharts": "^10.3.3",
+        "highcharts-react-official": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -12375,6 +12377,20 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highcharts": {
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.3.tgz",
+      "integrity": "sha512-r7wgUPQI9tr3jFDn3XT36qsNwEIZYcfgz4mkKEA6E4nn5p86y+u1EZjazIG4TRkl5/gmGRtkBUiZW81g029RIw=="
+    },
+    "node_modules/highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "peerDependencies": {
+        "highcharts": ">=6.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/hmac-drbg": {
@@ -30720,6 +30736,16 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "highcharts": {
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.3.tgz",
+      "integrity": "sha512-r7wgUPQI9tr3jFDn3XT36qsNwEIZYcfgz4mkKEA6E4nn5p86y+u1EZjazIG4TRkl5/gmGRtkBUiZW81g029RIw=="
+    },
+    "highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "highcharts": "^10.3.3",
+    "highcharts-react-official": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/features/prefecture-population/components/population-graph/PopulationGraph.stories.tsx
+++ b/src/features/prefecture-population/components/population-graph/PopulationGraph.stories.tsx
@@ -1,0 +1,139 @@
+import { ComponentMeta } from "@storybook/react";
+import PopulationGraph from "./PopulationGraph";
+
+export default {
+  component: PopulationGraph,
+} as ComponentMeta<typeof PopulationGraph>;
+
+const populationData = [
+  {
+    prefName: "東京都",
+    prefCode: 1,
+    populations: [
+      {
+        year: 1980,
+        value: 12817,
+      },
+      {
+        year: 1985,
+        value: 12707,
+      },
+      {
+        year: 1990,
+        value: 12571,
+      },
+      {
+        year: 1995,
+        value: 12602,
+      },
+      {
+        year: 2000,
+        value: 12199,
+      },
+      {
+        year: 2005,
+        value: 11518,
+      },
+      {
+        year: 2010,
+        value: 10888,
+      },
+      {
+        year: 2015,
+        value: 10133,
+      },
+      {
+        year: 2020,
+        value: 9302,
+      },
+      {
+        year: 2025,
+        value: 8431,
+      },
+      {
+        year: 2030,
+        value: 7610,
+      },
+      {
+        year: 2035,
+        value: 6816,
+      },
+      {
+        year: 2040,
+        value: 6048,
+      },
+      {
+        year: 2045,
+        value: 5324,
+      },
+    ],
+  },
+  {
+    prefName: "大阪府",
+    prefCode: 2,
+    populations: [
+      {
+        year: 1980,
+        value: 1281,
+      },
+      {
+        year: 1985,
+        value: 1270,
+      },
+      {
+        year: 1990,
+        value: 1257,
+      },
+      {
+        year: 1995,
+        value: 1260,
+      },
+      {
+        year: 2000,
+        value: 1219,
+      },
+      {
+        year: 2005,
+        value: 1151,
+      },
+      {
+        year: 2010,
+        value: 1088,
+      },
+      {
+        year: 2015,
+        value: 1013,
+      },
+      {
+        year: 2020,
+        value: 930,
+      },
+      {
+        year: 2025,
+        value: 843,
+      },
+      {
+        year: 2030,
+        value: 761,
+      },
+      {
+        year: 2035,
+        value: 681,
+      },
+      {
+        year: 2040,
+        value: 604,
+      },
+      {
+        year: 2045,
+        value: 532,
+      },
+    ],
+  },
+];
+
+export const Default = {
+  render: () => {
+    return <PopulationGraph populationData={populationData} />;
+  },
+};

--- a/src/features/prefecture-population/components/population-graph/PopulationGraph.tsx
+++ b/src/features/prefecture-population/components/population-graph/PopulationGraph.tsx
@@ -1,0 +1,47 @@
+import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+import { PrefecturePopulation } from "../../types";
+
+type Props = {
+  populationData: PrefecturePopulation[];
+};
+
+const PopulationGraph = ({ populationData }: Props) => {
+  const series: Highcharts.SeriesOptionsType[] = [];
+  const categories = populationData
+    .at(0)
+    ?.populations.map((d) => String(d.year));
+  populationData.map((pData) => {
+    const data = pData.populations.map((d) => d.value);
+    series.push({
+      type: "line",
+      name: pData.prefName,
+      data: data,
+    });
+  });
+
+  const options: Highcharts.Options = {
+    title: {
+      text: "",
+    },
+    xAxis: {
+      title: {
+        text: "年度",
+      },
+      categories: categories,
+    },
+    yAxis: {
+      title: {
+        text: "総人口数",
+      },
+    },
+    series:
+      series.length === 0
+        ? [{ type: "line", name: "都道府県名", data: [] }]
+        : series,
+  };
+
+  return <HighchartsReact highcharts={Highcharts} options={options} />;
+};
+
+export default PopulationGraph;

--- a/src/features/prefecture-population/types/index.ts
+++ b/src/features/prefecture-population/types/index.ts
@@ -6,3 +6,7 @@ export type Prefecture = {
 export type PrefectureCheckbox = Prefecture & {
   isChecked: boolean;
 };
+
+export type PrefecturePopulation = Prefecture & {
+  populations: { year: number; value: number }[];
+};


### PR DESCRIPTION
## issue

- #7 

## why

- グラフ表示によって総人口の推移を可視化するため

## what

- Highchartsのインストール
- 型の定義
- PopulationGraphコンポーネントの作成
- storiesの作成 

## UIスクリーンショット
![Screenshot 2023-02-09 at 05-15-46 features _ prefecture-population _ components _ population-graph _ PopulationGraph - Default ⋅ Storybook](https://user-images.githubusercontent.com/106266114/217641460-4ffecf83-536d-4083-9984-6bf191616476.png)

