### PR TITLE
#11_[API繋ぎ込み] 総人口推移グラフ

### DIFF
--- a/src/features/prefecture-population/api/getPopulations.ts
+++ b/src/features/prefecture-population/api/getPopulations.ts
@@ -1,0 +1,21 @@
+import { resasClient } from "../../../lib/axios";
+import { PopulationData } from "../types";
+
+export const getPopulations = (
+  prefCode: number
+): Promise<{
+  data: {
+    result: {
+      data: {
+        data: PopulationData[];
+      }[];
+    };
+  };
+}> => {
+  return resasClient.get("/population/composition/perYear", {
+    params: {
+      prefCode: prefCode,
+      cityCode: "-",
+    },
+  });
+};

--- a/src/features/prefecture-population/components/index.tsx
+++ b/src/features/prefecture-population/components/index.tsx
@@ -1,9 +1,12 @@
 import Header from "../../../components/header/Header";
+import { usePrefecturePopulations } from "../hooks/usePrefecturePopulations";
 import { usePrefectureCheckboxes } from "../hooks/usePrefectureCheckboxes";
+import PopulationGraph from "./population-graph/PopulationGraph";
 import PrefectureCheckboxes from "./prefecture-checkboxes/PrefectureCheckboxes";
 
 export const PrefecturePopulationPage = () => {
   const { prefectureCheckboxes, toggle } = usePrefectureCheckboxes();
+  const { populationData } = usePrefecturePopulations(prefectureCheckboxes);
 
   return (
     <>
@@ -12,6 +15,7 @@ export const PrefecturePopulationPage = () => {
         prefectureCheckboxes={prefectureCheckboxes}
         toggle={toggle}
       />
+      <PopulationGraph populationData={populationData()} />
     </>
   );
 };

--- a/src/features/prefecture-population/hooks/usePrefecturePopulations.ts
+++ b/src/features/prefecture-population/hooks/usePrefecturePopulations.ts
@@ -1,0 +1,16 @@
+import { PrefectureCheckbox } from "../types";
+import { useQueryPopulations } from "./useQueryPopulations";
+
+export const usePrefecturePopulations = (
+  prefectureCheckboxes: PrefectureCheckbox[]
+) => {
+  const results = useQueryPopulations(
+    prefectureCheckboxes.filter(
+      (prefectureCheckbox) => prefectureCheckbox.isChecked
+    )
+  );
+  const isLoading = results.some((result) => result.isLoading);
+  const populationData = () => results.flatMap((result) => result.data ?? []);
+
+  return { isLoading, populationData };
+};

--- a/src/features/prefecture-population/hooks/useQueryPopulations.ts
+++ b/src/features/prefecture-population/hooks/useQueryPopulations.ts
@@ -1,0 +1,26 @@
+import { useQueries } from "@tanstack/react-query";
+import { getPopulations } from "../api/getPopulations";
+import { PopulationData, Prefecture, PrefecturePopulation } from "../types";
+
+export const useQueryPopulations = (prefectures: Prefecture[]) => {
+  return useQueries({
+    queries: prefectures.map((prefecture) => {
+      return {
+        queryKey: ["populations", prefecture.prefCode],
+        queryFn: () => getPopulations(prefecture.prefCode),
+        select: (populations: {
+          data: {
+            result: {
+              data: {
+                data: PopulationData[];
+              }[];
+            };
+          };
+        }): PrefecturePopulation => ({
+          ...prefecture,
+          populations: populations.data.result.data.at(0)?.data ?? [],
+        }),
+      };
+    }),
+  });
+};

--- a/src/features/prefecture-population/types/index.ts
+++ b/src/features/prefecture-population/types/index.ts
@@ -7,6 +7,8 @@ export type PrefectureCheckbox = Prefecture & {
   isChecked: boolean;
 };
 
+export type PopulationData = { year: number; value: number };
+
 export type PrefecturePopulation = Prefecture & {
-  populations: { year: number; value: number }[];
+  populations: PopulationData[];
 };

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -1,3 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: Infinity } },
+});


### PR DESCRIPTION
## issue

- #11 

## why（なぜやるのか）

- 選択した都道府県の総人口の推移をAPIから取得し、それをグラフに表示させたいため

## what（なにをやったのか）

- useQueryPopulations（useQueryをラップした総人口推移取得用hooks）を定義
- usePrefecturePopulations（PopulationGraph用のロジックを切り出したhooks）を定義
- PrefecturePopulationPageコンポーネントに配置
- queryのstaleTimeをInfiniteに変更

## UIスクリーンショット
![Screenshot 2023-02-10 at 02-10-14 features _ prefecture-population _ components - Default ⋅ Storybook](https://user-images.githubusercontent.com/106266114/217887199-bea9251e-cd0d-41ec-8578-9b8eb1449db8.png)
